### PR TITLE
Fixed Grapheme Clusters Issue

### DIFF
--- a/Sources/ReadMoreTextView.swift
+++ b/Sources/ReadMoreTextView.swift
@@ -274,7 +274,7 @@ public class ReadMoreTextView: UITextView {
 
         if let originalAttributedText = _originalAttributedText?.mutableCopy() as? NSMutableAttributedString {
             attributedText = _originalAttributedText
-            let range = NSRange(location: 0, length: text.length)
+            let range = NSRange(location: 0, length: text.unicodeScalars.count)
             if let attributedReadLessText = attributedReadLessText {
                 originalAttributedText.append(attributedReadLessText)
             }


### PR DESCRIPTION
Currently If you set `تطبيقاً ذكياً وجهازاً يوصل` as the text  of the text View and set the `shouldTrim` property to false,  the text View will display  `تطبيقاً ذكياً وجهازاً يوصل صل` as the text, repeating the last two characters. This is happening because `اً` is a single grapheme cluster and is treated as a single character by swift `String` where as `NSString` and `NSAttributedString` doesn't respect grapheme cluster boundaries and treat this as two unicode scalars. 

The `count` on Swift String and `length` on NSString/NSAttributedString will be different for the above string due to which the range replacement code was failing. I have replaced the `length` with `unicodeScalars.count` which returns the number of unicode scalars in the string which is what `textStorage` is expecting.
