### PR TITLE
Fix problem with string length and composed emojis

### DIFF
--- a/Example/ReadMoreTextView/ViewController.swift
+++ b/Example/ReadMoreTextView/ViewController.swift
@@ -23,7 +23,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        readMoreTextView.text = "Lorem http://ipsum.com dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda."
+        readMoreTextView.text = "👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦 Lorem http://ipsum.com dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda."
         let readMoreTextAttributes: [NSAttributedStringKey: Any] = [
           NSAttributedStringKey.foregroundColor: view.tintColor,
           NSAttributedStringKey.font: UIFont.boldSystemFont(ofSize: 16)

--- a/Sources/ReadMoreTextView.swift
+++ b/Sources/ReadMoreTextView.swift
@@ -231,7 +231,7 @@ public class ReadMoreTextView: UITextView {
     private var _originalAttributedText: NSAttributedString!
     private var _originalTextLength: Int {
         get {
-            return _originalAttributedText?.length ?? 0
+            return _originalAttributedText?.string.length ?? 0
         }
     }
     
@@ -274,7 +274,7 @@ public class ReadMoreTextView: UITextView {
 
         if let originalAttributedText = _originalAttributedText?.mutableCopy() as? NSMutableAttributedString {
             attributedText = _originalAttributedText
-            let range = NSRange(location: 0, length: text.unicodeScalars.count)
+            let range = NSRange(location: 0, length: text.length)
             if let attributedReadLessText = attributedReadLessText {
                 originalAttributedText.append(attributedReadLessText)
             }
@@ -305,7 +305,7 @@ public class ReadMoreTextView: UITextView {
         else {
             let lastCharacterIndex = characterIndexBeforeTrim(range: rangeThatFitsContainer)
             if lastCharacterIndex > 0 {
-                return NSMakeRange(lastCharacterIndex, textStorage.length - lastCharacterIndex)
+                return NSMakeRange(lastCharacterIndex, textStorage.string.length - lastCharacterIndex)
             }
             else {
                 return NSMakeRange(NSNotFound, 0)


### PR DESCRIPTION
Hey @ilyapuchka thank you for this amazing code, not only useful to use it but also amazing to learn more about TextKit. Great job. 👏 

I've noticed that when you have composed emojis like `👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦` it was counting the characters using `unicodeScalars`.

| Before  | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone XR - 2019-07-10 at 13 29 27](https://user-images.githubusercontent.com/508636/60987111-552b7f00-a317-11e9-964e-24c3de43d699.png) |  ![Simulator Screen Shot - iPhone XR - 2019-07-10 at 13 29 55](https://user-images.githubusercontent.com/508636/60987134-5ceb2380-a317-11e9-9c31-1ebc6a1c33bd.png) |

What you think?

